### PR TITLE
Registers the VS Code Language

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -12,7 +12,8 @@ const plugin = {
     {
       name: "XML",
       parsers: ["xml"],
-      extensions: [".xml"]
+      extensions: [".xml"],
+      vscodeLanguageIds: ["xml"]
     }
   ],
   parsers: {


### PR DESCRIPTION
Registering the xml language for VS Code allows the VS Code extension to use this plugin.