### PR TITLE
Prettier DITA files

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -12,7 +12,7 @@ const plugin = {
     {
       name: "XML",
       parsers: ["xml"],
-      extensions: [".xml"],
+      extensions: [".dita", ".ditamap", ".ditaval", ".xml"],
       vscodeLanguageIds: ["xml"]
     }
   ],


### PR DESCRIPTION
Extend the list of extensions that Prettier should treat as XML to include those commonly used by the [Darwin Information Typing Architecture (DITA)](http://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part0-overview.html).

Signed-off-by: Roger Sheen <roger@infotexture.net>

