### PR TITLE
DRAFT: xml-tools poc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.eslintcache
 /coverage/
 /node_modules/
+
+.idea

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/prettier/plugin-xml#readme",
   "dependencies": {
+    "@xml-tools/parser": "0.4.0",
     "prettier": ">=1.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,6 +356,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@xml-tools/parser@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@xml-tools/parser/-/parser-0.4.0.tgz#cc1cd9bbba39d9ee5563082d0656ce57b144f691"
+  integrity sha512-capRg2KdWYkz2QF/ee7L+R7g92eQYgTUIkQm4nwWQEF6oNH09MGvS5nDwGp7BDg5z/UkJ8AQQBJFTLSbv7wIPA==
+  dependencies:
+    chevrotain "6.5.0"
+
 abab@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.2.tgz#a2fba1b122c69a85caa02d10f9270c7219709a9d"
@@ -717,6 +724,13 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+chevrotain@6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-6.5.0.tgz#dcbef415516b0af80fd423cc0d96b28d3f11374e"
+  integrity sha512-BwqQ/AgmKJ8jcMEjaSnfMybnKMgGTrtDKowfTP3pX4jwVy0kNjRsT/AP6h+wC3+3NC+X8X15VWBnTCQlX+wQFg==
+  dependencies:
+    regexp-to-ast "0.4.0"
 
 chownr@^1.1.1:
   version "1.1.3"
@@ -3243,6 +3257,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexp-to-ast@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/regexp-to-ast/-/regexp-to-ast-0.4.0.tgz#f3dbcb42726cd71902ba50193f63eab5325cd7cb"
+  integrity sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==
 
 regexpp@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Partial Prototype using `@xml-tools/parser` to build the existing AST structure
that is currently being bulid using a heavy fork of `fast-xml-parser`.

I do not think this is the bet approach, I would recommend to implement the formatter
directly on the CST (Concrete Syntax Tree) produced by `@xml-tools/parser`.
Using the CST Visitor API provided by `@xml-tools/parser`.

As the CST seems **closest** to the actual syntax structure that a formatter is interested in, e.g:
- includes comments
- includes mixed and WS element content's values.

Additionally an XML structure in general is simple so even though the CST structure is "ugly" its not a huge problem and no need to simplify it for more processing.

- References:
- [CST Printer for TOML](https://github.com/bd82/toml-tools/blob/master/packages/prettier-plugin-toml/lib/printer.js)
- [CST Printer for Java](https://github.com/jhipster/prettier-java/tree/master/packages/prettier-plugin-java/src/printers)
- [XML-Tools mono repo](https://github.com/sap/xml-tools) 
