### PR TITLE
Fixes standalone mode & comment issues

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@
 /.*ignore
 /yarn.lock
 /LICENSE
+/.idea

--- a/src/parse.js
+++ b/src/parse.js
@@ -8,9 +8,8 @@ const endTagPattern = `((\\/)${tagNamePattern}\\s*>)`;
 
 const commentPattern = "(!--)([\\s\\S\\n]*?)-->";
 const declPattern = "((\\?xml)(-model)?)(.+)\\?>";
-const docTypePattern = "(!(doctype|DOCTYPE))";
 
-const tagPattern = `<(${cDataPattern}|${startTagPattern}|${endTagPattern}|${commentPattern}|${declPattern}|${docTypePattern})([^<]*)`;
+const tagPattern = `<(${cDataPattern}|${startTagPattern}|${endTagPattern}|${commentPattern}|${declPattern})([^<]*)`;
 
 class XMLNode {
   constructor(tagname, opts) {
@@ -69,16 +68,6 @@ const parse = (text, _parsers, _opts) => {
         new XMLNode("!comment", {
           parent: node,
           value: tag[0].trim(),
-          locStart: tag.index,
-          locEnd: tag.index + tag[0].trim().length
-        })
-      );
-    } else if ((tag[21] || "").toLowerCase() === "doctype") {
-      node.children.push(
-        new XMLNode(`!doctype`, {
-          parent: node,
-          value: tag[0].trim(),
-          attrs: tag[22].trim().replace(/>$/, ""),
           locStart: tag.index,
           locEnd: tag.index + tag[0].trim().length
         })

--- a/src/parse.js
+++ b/src/parse.js
@@ -73,12 +73,12 @@ const parse = (text, _parsers, _opts) => {
           locEnd: tag.index + tag[0].trim().length
         })
       );
-    } else if ((tag[21]||'').toLowerCase() === 'doctype') {
+    } else if ((tag[21] || "").toLowerCase() === "doctype") {
       node.children.push(
         new XMLNode(`!doctype`, {
           parent: node,
           value: tag[0].trim(),
-          attrs: tag[22].trim().replace(/>$/, ''),
+          attrs: tag[22].trim().replace(/>$/, ""),
           locStart: tag.index,
           locEnd: tag.index + tag[0].trim().length
         })

--- a/src/parse.js
+++ b/src/parse.js
@@ -8,8 +8,9 @@ const endTagPattern = `((\\/)${tagNamePattern}\\s*>)`;
 
 const commentPattern = "(!--)([\\s\\S\\n]*?)-->";
 const declPattern = "((\\?xml)(-model)?)(.+)\\?>";
+const docTypePattern = "(!(doctype|DOCTYPE))";
 
-const tagPattern = `<(${cDataPattern}|${startTagPattern}|${endTagPattern}|${commentPattern}|${declPattern})([^<]*)`;
+const tagPattern = `<(${cDataPattern}|${startTagPattern}|${endTagPattern}|${commentPattern}|${declPattern}|${docTypePattern})([^<]*)`;
 
 class XMLNode {
   constructor(tagname, opts) {
@@ -68,6 +69,16 @@ const parse = (text, _parsers, _opts) => {
         new XMLNode("!comment", {
           parent: node,
           value: tag[0].trim(),
+          locStart: tag.index,
+          locEnd: tag.index + tag[0].trim().length
+        })
+      );
+    } else if ((tag[21]||'').toLowerCase() === 'doctype') {
+      node.children.push(
+        new XMLNode(`!doctype`, {
+          parent: node,
+          value: tag[0].trim(),
+          attrs: tag[22].trim().replace(/>$/, ''),
           locStart: tag.index,
           locEnd: tag.index + tag[0].trim().length
         })

--- a/src/parse.js
+++ b/src/parse.js
@@ -6,7 +6,7 @@ const tagNamePattern = "(([\\w:\\-._]*:)?([\\w:\\-._]+))";
 const startTagPattern = `${tagNamePattern}([^>]*)>`;
 const endTagPattern = `((\\/)${tagNamePattern}\\s*>)`;
 
-const commentPattern = "(!--)(.+?)-->";
+const commentPattern = "(!--)([\\s\\S\\n]*?)-->";
 const declPattern = "((\\?xml)(-model)?)(.+)\\?>";
 
 const tagPattern = `<(${cDataPattern}|${startTagPattern}|${endTagPattern}|${commentPattern}|${declPattern})([^<]*)`;
@@ -67,7 +67,7 @@ const parse = (text, _parsers, _opts) => {
       node.children.push(
         new XMLNode("!comment", {
           parent: node,
-          value: tag[15].trim(),
+          value: tag[0].trim(),
           locStart: tag.index,
           locEnd: tag.index + tag[0].trim().length
         })

--- a/src/print.js
+++ b/src/print.js
@@ -47,7 +47,7 @@ const genericPrint = (path, opts, print) => {
     return concat([join(hardline, path.map(print, "children")), hardline]);
   }
 
-  if (tagname === "!comment") {
+  if (tagname === "!comment" || tagname === '!doctype') {
     return group(concat([value]));
   }
 

--- a/src/print.js
+++ b/src/print.js
@@ -47,7 +47,7 @@ const genericPrint = (path, opts, print) => {
     return concat([join(hardline, path.map(print, "children")), hardline]);
   }
 
-  if (tagname === "!comment" || tagname === '!doctype') {
+  if (tagname === "!comment" || tagname === "!doctype") {
     return group(concat([value]));
   }
 

--- a/src/print.js
+++ b/src/print.js
@@ -47,7 +47,7 @@ const genericPrint = (path, opts, print) => {
     return concat([join(hardline, path.map(print, "children")), hardline]);
   }
 
-  if (tagname === "!comment" || tagname === "!doctype") {
+  if (tagname === "!comment") {
     return group(concat([value]));
   }
 

--- a/src/print.js
+++ b/src/print.js
@@ -6,7 +6,7 @@ const {
   join,
   line,
   softline
-} = require("prettier").doc.builders;
+} = require("prettier/standalone").doc.builders;
 
 const printAttrs = attrs => {
   if (Object.keys(attrs).length === 0) {

--- a/src/print.js
+++ b/src/print.js
@@ -49,7 +49,7 @@ const genericPrint = (path, opts, print) => {
 
   if (tagname === "!comment") {
     return group(
-      concat(["<!--", indent(concat([line, value])), concat([line, "-->"])])
+      concat([value])
     );
   }
 

--- a/src/print.js
+++ b/src/print.js
@@ -48,9 +48,7 @@ const genericPrint = (path, opts, print) => {
   }
 
   if (tagname === "!comment") {
-    return group(
-      concat([value])
-    );
+    return group(concat([value]));
   }
 
   if (Object.keys(children).length === 0 && !value && opts.xmlSelfClosingTags) {

--- a/test/comment.test.js
+++ b/test/comment.test.js
@@ -12,14 +12,14 @@ describe("comment", () => {
       <foo>
         <!-- This is a single line comment -->
         <bar />
-        <!-- The spring-boot version should match the one managed by
-        https://someurl.com/yada/\${blah-yada.etc} -->
+        <!-- This comment contains links, is multiline and comment opening on the same line
+        as the text of the comment https://someurl.com/yada/\${blah-yada.etc} -->
         <baz>
           <!--Single line no inner space-->
           <qux />
         </baz>
         <!--
-        Enable the line below to have remote debugging of your application on port 5005
+        Comment contains commented tags and is multi line 
         <commented-tag>-abc:def=something=gh_ih,jk=y,number=5005</commented-tag>
         -->
       </foo>

--- a/test/comment.test.js
+++ b/test/comment.test.js
@@ -3,13 +3,25 @@ const { here } = require("./utils");
 describe("comment", () => {
   test("renders appropriately", () => {
     const content = here(`
+      <!--
+      ~ Copyright (C) Some Corporation. All Rights Reserved.
+      ~
+      ~ Yada yada GNU General Public License
+      ~ see <http://www.gnu.org/licenses/>.
+      -->
       <foo>
-        <!-- this is a comment -->
+        <!-- This is a single line comment -->
         <bar />
-        <!-- this is another comment -->
+        <!-- The spring-boot version should match the one managed by
+        https://someurl.com/yada/\${blah-yada.etc} -->
         <baz>
+          <!--Single line no inner space-->
           <qux />
         </baz>
+        <!--
+        Enable the line below to have remote debugging of your application on port 5005
+        <commented-tag>-abc:def=something=gh_ih,jk=y,number=5005</commented-tag>
+        -->
       </foo>
     `);
 

--- a/test/doctype.test.js
+++ b/test/doctype.test.js
@@ -5,6 +5,9 @@ describe("doctype", () => {
     const content = here(`
       <?xml version="1.0" encoding="UTF-8" ?>
       <?xml-model href="model.rnc" type="application/relax-ng-compact-sync-syntax" ?>
+      <!DOCTYPE foo PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+                               "http://docbook.org/xml/4.5/docbookx.dtd">
+      <!DOCTYPE foo PUBLIC "-//OASIS//DTD DITA Task//EN" "foo.dtd">
       <foo />
     `);
 

--- a/test/doctype.test.js
+++ b/test/doctype.test.js
@@ -5,9 +5,6 @@ describe("doctype", () => {
     const content = here(`
       <?xml version="1.0" encoding="UTF-8" ?>
       <?xml-model href="model.rnc" type="application/relax-ng-compact-sync-syntax" ?>
-      <!DOCTYPE foo PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-                               "http://docbook.org/xml/4.5/docbookx.dtd">
-      <!DOCTYPE foo PUBLIC "-//OASIS//DTD DITA Task//EN" "foo.dtd">
       <foo />
     `);
 


### PR DESCRIPTION
# "Standalone mode" / Bundler-friendly

Using plugin-xml on web(pack) builds (in my case a react app), results in unusually long build times and compiler warnings. Looks like same issue as #28 

```
Compiled with warnings.

./node_modules/prettier/index.js
Critical dependency: the request of a dependency is an expression

./node_modules/prettier/index.js
Critical dependency: the request of a dependency is an expression

./node_modules/prettier/index.js
Critical dependency: the request of a dependency is an expression

./node_modules/prettier/third-party.js
Critical dependency: the request of a dependency is an expression

./node_modules/prettier/parser-typescript.js
Module not found: Can't resolve '@microsoft/typescript-etw' in '/yada/yada/node_modules/prettier'
```

This PR switches `print.js` to `require('prettier/standalone')` instead of `'prettier'` which works well in web builds and all (node) tests pass too.

Any objections to this approach? Alternatively there could be a `standalone.js` (same pattern that prettier itself follows) that does a whole different "build" of the plugin and somehow refactor `print.js` and `plugin.js` to minimize code duplication but seems unnecessary as this approach works fine.

# Comment Issues

In addition to #13 and #14 I found another issue where a comment containing the `<` and `>` chars with a link inside gets utterly transformed.

**Expected:**
```
    <!--
    ~ Copyright (C) Some Corporation. All Rights Reserved.
    ~
    ~ Yada yada GNU General Public License
    ~ see <http://www.gnu.org/licenses/>.
    -->
```
**Received:**
```xml
    <http: //www.gnu.org/licenses="" />

```

I didn't realise about https://github.com/prettier/plugin-xml/pull/30 until I had finished this but when I ran the changes on #30 with my XML updates - i.e. the ones on this PR - the tests didn't pass. Tests all pass with the changes on this PR as well as with the test XML on #30.

```
➜  prettier-plugin-xml git:(master) ✗ yarn test
yarn run v1.19.2
$ jest
 PASS  test/comment.test.js
 PASS  test/node.test.js
 PASS  test/attrs.test.js
 PASS  test/leaf.test.js
 PASS  test/arrays.test.js
 PASS  test/cdata.test.js
 PASS  test/location.test.js
 PASS  test/doctype.test.js

Test Suites: 8 passed, 8 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        1.256s
Ran all test suites.
✨  Done in 2.28s.
```
