### PR TITLE
修改prettier依赖，减少包体积

### DIFF
--- a/src/print.js
+++ b/src/print.js
@@ -7,7 +7,7 @@ const {
   line,
   literalline,
   softline
-} = require("prettier").doc.builders;
+} = require("prettier/doc").builders;
 
 const elementOnly = node => {
   const { CData, chardata, element, reference } = node.children;


### PR DESCRIPTION
项目引入改插件之后，没有必要require整个prettier包，只需要依赖的doc文件即可