### PR TITLE
Support XSLT documents

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -27,7 +27,9 @@ const plugin = {
         ".svg",
         ".wsdl",
         ".xml",
-        ".xsd"
+        ".xsd",
+        ".xsl",
+        ".xslt"
       ],
       vscodeLanguageIds: ["xml", "forcesourcemanifest"]
     }


### PR DESCRIPTION
XSLT documents are most commonly associated with the file suffixes .xsl or
.xslt. This observation is also made in the corresponding W3C standards
documents. When providing examples, the standards documents generally assume the
.xsl suffix.