### PR TITLE
Restore xmlSelfClosingSpace description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Below are the options (from [`src/plugin.ts`](src/plugin.ts)) that `@prettier/pl
 | `bracketSameLine`          | `--bracket-same-line`          |   `true`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#bracket-same-line)) |
 | `printWidth`               | `--print-width`                |    `80`    | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#print-width)).      |
 | `tabWidth`                 | `--tab-width`                  |    `2`     | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#tab-width)).        |
+| `xmlSelfClosingSpace`      | `--xml-self-closing-space`     |   `true`   | Adds a space before self-closing tags.                                                                |
 | `xmlWhitespaceSensitivity` | `--xml-whitespace-sensitivity` | `"strict"` | Options are `"strict"` and `"ignore"`. You may want `"ignore"`, [see below](#whitespace).             |
 
 Any of these can be added to your existing [prettier configuration


### PR DESCRIPTION
- The `xmlSelfClosingSpace` option was removed with #232, and later restored with #300 to re-resolve #11, but that commit (6b84c49) did not update the [README](https://github.com/prettier/plugin-xml/blob/main/README.md). 
  - 62106b5 restores the entry in the [Configuration](https://github.com/prettier/plugin-xml#configuration) table.

- The `plugin.js` file was renamed to `plugin.ts` during the conversion to TypeScript in 53ca85e. 
  - bd694ff fixes the broken link.