### PR TITLE
Format XSLT files

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -151,6 +151,8 @@ const plugin: Plugin = {
         ".xml.dist",
         ".xproj",
         ".xsd",
+        ".xsl",
+        ".xslt",
         ".xspec",
         ".xul",
         ".zcml"


### PR DESCRIPTION
Prettier currently complains when formatting [Extensible Stylesheet Language Transformations](https://en.wikipedia.org/wiki/XSLT):

```console
$ prettier --write stylesheet.xsl
[error] No parser could be inferred for file: stylesheet.xsl
```

The parser can be explicitly set on the CLI with `prettier --write stylesheet.xsl --parser xml`, but this is easy to forget.

This PR extends the list of extensions that Prettier should treat as XML to include those commonly used by XSL stylesheets.
