### PR TITLE
Fix issue with <flow> node in XML file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prettier/plugin-xml",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "prettier plugin for XML",
   "type": "module",
   "main": "src/plugin.js",

--- a/src/embed.js
+++ b/src/embed.js
@@ -47,6 +47,13 @@ function getParser(node, opts) {
     return null;
   }
 
+  // If somehow there is a "flow" node in XML file (Salesforce files for ex.)
+  // we should stick to xml parser.
+  // Flow is written as JS anyway, annotated by @flow in the code.
+  if (parser === "flow") {
+    return null;
+  }  
+
   // If this is a style tag with a text/xxx type then we will use xxx as the
   // name of the parser
   if (parser === "style" && attribute) {

--- a/test/__snapshots__/format.test.js.snap
+++ b/test/__snapshots__/format.test.js.snap
@@ -317,6 +317,20 @@ use {
 "
 `;
 
+exports[`xml with flow tag 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>This is a blank permission</description>
+    <flowAccesses>
+        <enabled>true</enabled>
+        <flow>SF_Flow</flow>
+    </flowAccesses>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>Salesforce Flow Access</label>
+</PermissionSet>
+"
+`;
+
 exports[`xmlSelfClosingSpace => false 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"

--- a/test/flow_fixture.xml
+++ b/test/flow_fixture.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>This is a blank permission</description>
+    <flowAccesses>
+        <enabled>true</enabled>
+        <flow>SF_Flow</flow>
+    </flowAccesses>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>Salesforce Flow Access</label>
+</PermissionSet>

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -7,6 +7,11 @@ const fixture = readFileSync(
   "utf-8"
 );
 
+const flowFixture = readFileSync(
+  new URL("./flow_fixture.xml", import.meta.url),
+  "utf-8"
+);
+
 function format(content, opts = {}) {
   return prettier.format(content, {
     ...opts,
@@ -61,5 +66,12 @@ test("singleAttributePerLine => true", async () => {
     xmlWhitespaceSensitivity: "ignore"
   });
 
+  expect(formatted).toMatchSnapshot();
+});
+
+test("xml with flow tag", async () => {
+  const formatted = await format(flowFixture, {
+    xmlSelfClosingSpace: false
+  });
   expect(formatted).toMatchSnapshot();
 });


### PR DESCRIPTION
Hi!
While I was working on Salesforce project I wanted to use prettrier xml formatter as my git hook, but I had one problem: when I was working on permission set XML file with the <flow> node inside of it, it was interpreted as a flow type - which should be formatted with flow plugin - it shouldn't be the case. 