### PR TITLE
feat: implement xmlWhitespaceSensitivity: 'preserve'

### DIFF
--- a/.github/ISSUE_TEMPLATE/formatting.yml
+++ b/.github/ISSUE_TEMPLATE/formatting.yml
@@ -24,7 +24,8 @@ body:
       description: What value do you have the `xmlWhitespaceSensitivity` option set to? (Defaults to `"strict"`.) Be 100% sure changing this to `"ignore"` doesn't fix your issue!
       options:
         - "strict"
-        - "ignore"
+        - "preserve"
+        - "ignore"        
     validations:
       required: true
   - type: dropdown

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Below are the options (from [`src/plugin.js`](src/plugin.js)) that `@prettier/pl
 | `singleAttributePerLine`   | `--single-attribute-per-line`  |  `false`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#single-attribute-per-line)) |
 | `tabWidth`                 | `--tab-width`                  |    `2`     | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#tab-width)).                |
 | `xmlSelfClosingSpace`      | `--xml-self-closing-space`     |   `true`   | Adds a space before self-closing tags.                                                                        |
-| `xmlWhitespaceSensitivity` | `--xml-whitespace-sensitivity` | `"strict"` | Options are `"strict"` and `"ignore"`. You may want `"ignore"`, [see below](#whitespace).                     |
+| `xmlWhitespaceSensitivity` | `--xml-whitespace-sensitivity` | `"strict"` | Options are `"strict"`， `"preserve"` and `"ignore"`. You may want `"preserve"`, [see below](#whitespace).                     |
 
 Any of these can be added to your existing [prettier configuration
 file](https://prettier.io/docs/en/configuration.html). For example:
@@ -74,7 +74,9 @@ prettier --tab-width 4 --write '**/*.xml'
 
 In XML, by default, all whitespace inside elements has semantic meaning. For prettier to maintain its contract of not changing the semantic meaning of your program, this means the default for `xmlWhitespaceSensitivity` is `"strict"`. When running in this mode, prettier's ability to rearrange your markup is somewhat limited, as it has to maintain the exact amount of whitespace that you input within elements.
 
-If you're sure that the XML files that you're formatting do not require whitespace sensitivity, you can use the `"ignore"` option, as this will produce a standardized amount of whitespace. This will fix any indentation issues, and collapse excess blank lines (max of 1 blank line). For most folks most of the time, this is probably the option that you want.
+You can use the `"preserve"` option, if you want to preserve the whitespaces of the text node within XML elements and attributes. (see [Issue #478](https://github.com/prettier/plugin-xml/issues/478)).  For most folks most of the time, this is probably the option that you want.
+
+If you're sure that the XML files that you're formatting do not require whitespace sensitivity, you can use the `"ignore"` option, as this will produce a standardized amount of whitespace. This will fix any indentation issues, and collapse excess blank lines (max of 1 blank line).
 
 ### Ignore ranges
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -29,6 +29,10 @@ const plugin = {
           description: "Whitespaces are considered sensitive in all elements."
         },
         {
+          value: "preserve",
+          description: "Whitespaces within text nodes in XML elements and attributes are considered sensitive."
+        },
+        {
           value: "ignore",
           description: "Whitespaces are considered insensitive in all elements."
         }

--- a/test/__snapshots__/format.test.js.snap
+++ b/test/__snapshots__/format.test.js.snap
@@ -69,6 +69,13 @@ use {
   <span>content</span>
 
   <div>
+    text with space
+    <div>
+      <hr />
+    </div>
+  </div>
+
+  <div>
     even more
     <content />
   </div>
@@ -146,6 +153,13 @@ use {
   <span>content</span>
 
   <div>
+    text with space
+    <div>
+      <hr/>
+    </div>
+  </div>
+
+  <div>
     even more
     <content/>
   </div>
@@ -220,6 +234,7 @@ use {
     content
   </span>
 
+  <div> text   with space<div><hr /></div>   </div>
 
   <div>
     even more
@@ -313,6 +328,13 @@ use {
   <span>content</span>
 
   <div>
+    text with space
+    <div>
+      <hr />
+    </div>
+  </div>
+
+  <div>
     even more
     <content />
   </div>
@@ -392,6 +414,13 @@ use {
   <span>content</span>
 
   <div>
+    text with space
+    <div>
+      <hr/>
+    </div>
+  </div>
+
+  <div>
     even more
     <content/>
   </div>
@@ -469,6 +498,92 @@ use {
     elementum ut.
   </p>
   <span>content</span>
+
+  <div>
+    text with space
+    <div>
+      <hr />
+    </div>
+  </div>
+
+  <div>
+    even more
+    <content />
+  </div>
+</svg>
+<!-- bar -->
+"
+`;
+
+exports[`xmlWhitespaceSensitivity => preserve 1`] = `
+"<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<?xml-model href="project.rnc" type="application/relax-ng-compact-syntax"?>
+<!-- foo -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  width="200"
+  height="100"
+  viewBox="0 0 200 100"
+>
+  <title>Style inheritance and the use element</title>
+  <desc _attr="attr">
+    &anp; &#12345;
+    <![CDATA[
+      foo
+    ]]>
+    bar
+  </desc>
+  <?pagebreak?>
+
+  <style />
+  <style />
+  <style type="text/css">
+circle {
+  stroke-opacity: 0.7;
+}
+.special circle {
+  stroke: green;
+}
+use {
+  stroke: purple;
+  fill: orange;
+}
+  </style>
+  <script value="lint" />
+
+  <yaml
+    myveryveryveryverylongattributename="myveryveryveryverylongattributevalue"
+  >
+- 1
+  - 2
+- 3
+  </yaml>
+
+  <!-- inner comment -->
+
+  <?pagebreak?>
+  <g class="special" style="fill: blue">
+    <circle id="c" cy="50" cx="50" r="40" stroke-width="20" />
+  </g>
+  <use xlink:href="#c" x="100" />
+  <ignored>
+    <!-- prettier-ignore-start -->
+      <   ignored   />
+    <!-- prettier-ignore-end -->
+  </ignored>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim. Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna. Curabitur molestie lorem et odio porta, et molestie libero laoreet. Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat. Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu, at condimentum neque elementum ut.
+  </p>
+  <span>
+    content
+  </span>
+
+  <div> text   with space<div>
+    <hr />
+  </div>   </div>
 
   <div>
     even more

--- a/test/fixture.xml
+++ b/test/fixture.xml
@@ -55,6 +55,7 @@
     content
   </span>
 
+  <div> text   with space<div><hr/></div>   </div>
 
   <div>
     even more

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -63,3 +63,12 @@ test("singleAttributePerLine => true", async () => {
 
   expect(formatted).toMatchSnapshot();
 });
+
+test("xmlWhitespaceSensitivity => preserve", async () => {
+  const formatted = await format(fixture, {
+    xmlWhitespaceSensitivity: "preserve"
+  });
+  console.log({formatted});
+
+  expect(formatted).toMatchSnapshot();
+});


### PR DESCRIPTION
Fixes [#478](https://github.com/prettier/plugin-xml/issues/478)

Add new suboption `preserve` to `xmlWhitespaceSensitivity`, to preserve significant whitespace within XML elements.  This PR should address all the cases where significant white space exists.

Specifically:

- spaces within string are preserved:
  ```
  // before and after prettier identical
  <v>some string    extra space</v>
  ```

- string with space(s) at the beginning and/or end:
  ```
  // before and after prettier identical
  <v>
    some  string
  </v>
   ```
   
- mixing elements within string literal is also supported, space(s) surrounding and within string literal will be preserved:
   ```
   before: <v> some  string<abc/>more string </v>
    after: <v> some  string<abc />more string </v>
   ```

See PR https://github.com/prettier/plugin-xml/pull/479 for more detail 