### PR TITLE
 Added feature to order XML attributes by key alphabetically while prioritizing xmlns attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
-- the `sortAttributesByKey: true | false` option has been added. See the README.
+- the `xmlSortAttributesByKey: true | false` option has been added. See the README.
 
 ## [3.0.0-alpha.0] - 2023-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+- the `sortAttributesByKey: true | false` option has been added. See the README.
+
 ## [3.0.0-alpha.0] - 2023-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ The `prettier` executable is now installed and ready for use:
 Below are the options (from [`src/plugin.js`](src/plugin.js)) that `@prettier/plugin-xml` currently supports:
 
 | API Option                 | CLI Option                     |  Default   | Description                                                                                                              |
-| -------------------------- | ------------------------------ | :--------: | ------------------------------------------------------------------------------------------------------------------------ |
+| -------------------------- | ------------------------------ | :--------: | ------------------------------------------------------------------------------------------------------------------------ | --- |
 | `bracketSameLine`          | `--bracket-same-line`          |   `true`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#bracket-same-line))                    |
 | `printWidth`               | `--print-width`                |    `80`    | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#print-width)).                         |
-| `singleAttributePerLine`   | `--single-attribute-per-line`  |  `false`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#single-attribute-per-line))            |
-| `sortAttributesByKey`      | `--sort-attributes-by-key`     |  `false`   | Orders XML attributes by key alphabetically while prioritizing xmlns attributes.                                         |
+| `singleAttributePerLine`   | `--single-attribute-per-line`  |  `false`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#single-attribute-per-line))            |     |
 | `tabWidth`                 | `--tab-width`                  |    `2`     | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#tab-width)).                           |
 | `xmlSelfClosingSpace`      | `--xml-self-closing-space`     |   `true`   | Adds a space before self-closing tags.                                                                                   |
+| `xmlSortAttributesByKey`   | `--xml-sort-attributes-by-key` |  `false`   | Orders XML attributes by key alphabetically while prioritizing xmlns attributes.                                         |
 | `xmlWhitespaceSensitivity` | `--xml-whitespace-sensitivity` | `"strict"` | Options are `"strict"`, `"preserve"`, and `"ignore"`. You may want `"ignore"` or `"preserve"`, [see below](#whitespace). |
 
 Any of these can be added to your existing [prettier configuration

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Below are the options (from [`src/plugin.js`](src/plugin.js)) that `@prettier/pl
 | `bracketSameLine`          | `--bracket-same-line`          |   `true`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#bracket-same-line))                    |
 | `printWidth`               | `--print-width`                |    `80`    | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#print-width)).                         |
 | `singleAttributePerLine`   | `--single-attribute-per-line`  |  `false`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#single-attribute-per-line))            |
+| `sortAttributesByKey`      | `--sort-attributes-by-key`     |  `false`   | Orders XML attributes by key alphabetically while prioritizing xmlns attributes.                                         |
 | `tabWidth`                 | `--tab-width`                  |    `2`     | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#tab-width)).                           |
 | `xmlSelfClosingSpace`      | `--xml-self-closing-space`     |   `true`   | Adds a space before self-closing tags.                                                                                   |
 | `xmlWhitespaceSensitivity` | `--xml-whitespace-sensitivity` | `"strict"` | Options are `"strict"`, `"preserve"`, and `"ignore"`. You may want `"ignore"` or `"preserve"`, [see below](#whitespace). |

--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ The `prettier` executable is now installed and ready for use:
 
 Below are the options (from [`src/plugin.js`](src/plugin.js)) that `@prettier/plugin-xml` currently supports:
 
-| API Option                 | CLI Option                     |  Default   | Description                                                                                                              |
-| -------------------------- | ------------------------------ | :--------: | ------------------------------------------------------------------------------------------------------------------------ | --- |
-| `bracketSameLine`          | `--bracket-same-line`          |   `true`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#bracket-same-line))                    |
-| `printWidth`               | `--print-width`                |    `80`    | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#print-width)).                         |
-| `singleAttributePerLine`   | `--single-attribute-per-line`  |  `false`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#single-attribute-per-line))            |     |
-| `tabWidth`                 | `--tab-width`                  |    `2`     | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#tab-width)).                           |
+| API Option                 | CLI Option                     |   Default    | Description                                                                                                              |
+| -------------------------- | ------------------------------ | :----------: | ------------------------------------------------------------------------------------------------------------------------ | --- |
+| `bracketSameLine`          | `--bracket-same-line`          |    `true`    | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#bracket-same-line))                    |
+| `printWidth`               | `--print-width`                |     `80`     | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#print-width)).                         |
+| `singleAttributePerLine`   | `--single-attribute-per-line`  |   `false`    | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#single-attribute-per-line))            |     |
+| `tabWidth`                 | `--tab-width`                  |     `2`      | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#tab-width)).                           |
 | `xmlQuoteAttributes`       | `--xml-quote-attributes`       | `"preserve"` | Options are `"preserve"`, `"single"`, and `"double"`                                                                     |
-| `xmlSelfClosingSpace`      | `--xml-self-closing-space`     |   `true`   | Adds a space before self-closing tags.                                                                                   |
-| `xmlSortAttributesByKey`   | `--xml-sort-attributes-by-key` |  `false`   | Orders XML attributes by key alphabetically while prioritizing xmlns attributes.                                         |
-| `xmlWhitespaceSensitivity` | `--xml-whitespace-sensitivity` | `"strict"` | Options are `"strict"`, `"preserve"`, and `"ignore"`. You may want `"ignore"` or `"preserve"`, [see below](#whitespace). |
+| `xmlSelfClosingSpace`      | `--xml-self-closing-space`     |    `true`    | Adds a space before self-closing tags.                                                                                   |
+| `xmlSortAttributesByKey`   | `--xml-sort-attributes-by-key` |   `false`    | Orders XML attributes by key alphabetically while prioritizing xmlns attributes.                                         |
+| `xmlWhitespaceSensitivity` | `--xml-whitespace-sensitivity` |  `"strict"`  | Options are `"strict"`, `"preserve"`, and `"ignore"`. You may want `"ignore"` or `"preserve"`, [see below](#whitespace). |
 
 Any of these can be added to your existing [prettier configuration
 file](https://prettier.io/docs/en/configuration.html). For example:

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -39,7 +39,13 @@ const plugin = {
         }
       ],
       since: "0.6.0"
-    }
+    },
+    sortAttributesByKey: {
+      type: "boolean",
+      category: "XML",
+      default: false,
+      description: "Orders XML attributes by key alphabetically while prioritizing xmlns attributes.",
+    },
   },
   defaultOptions: {
     printWidth: 80,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -40,12 +40,13 @@ const plugin = {
       ],
       since: "0.6.0"
     },
-    sortAttributesByKey: {
+    xmlSortAttributesByKey: {
       type: "boolean",
       category: "XML",
       default: false,
-      description: "Orders XML attributes by key alphabetically while prioritizing xmlns attributes.",
-    },
+      description:
+        "Orders XML attributes by key alphabetically while prioritizing xmlns attributes."
+    }
   },
   defaultOptions: {
     printWidth: 80,

--- a/src/printer.js
+++ b/src/printer.js
@@ -357,17 +357,29 @@ function printElement(path, opts, print) {
 
   const parts = [OPEN[0].image, Name[0].image];
 
-
   if (attribute) {
-    const separator = opts.singleAttributePerLine ? hardline : line;
-  
-    const attributes = path.map(print, "children", "attribute");
-    if (opts.sortAttributesByKey) {
+    const attributes = path.map(
+      (attributePath) => ({
+        node: attributePath.getValue(),
+        printed: print(attributePath)
+      }),
+      "children",
+      "attribute"
+    );
+
+    if (opts.xmlSortAttributesByKey) {
       sortAttributesByKey(attributes);
     }
 
+    const separator = opts.singleAttributePerLine ? hardline : line;
     parts.push(
-      indent([line, join(separator, attributes)])
+      indent([
+        line,
+        join(
+          separator,
+          attributes.map(({ printed }) => printed)
+        )
+      ])
     );
   }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,5 +1,6 @@
 import * as doc from "prettier/doc";
 import embed from "./embed.js";
+import sortAttributesByKey from "./util/sortAttributesByKey.js";
 
 const { fill, group, hardline, indent, join, line, literalline, softline } =
   doc.builders;
@@ -356,10 +357,17 @@ function printElement(path, opts, print) {
 
   const parts = [OPEN[0].image, Name[0].image];
 
+
   if (attribute) {
     const separator = opts.singleAttributePerLine ? hardline : line;
+  
+    const attributes = path.map(print, "children", "attribute");
+    if (opts.sortAttributesByKey) {
+      sortAttributesByKey(attributes);
+    }
+
     parts.push(
-      indent([line, join(separator, path.map(print, "children", "attribute"))])
+      indent([line, join(separator, attributes)])
     );
   }
 

--- a/src/util/sortAttributesByKey.js
+++ b/src/util/sortAttributesByKey.js
@@ -1,89 +1,98 @@
 /**
- * 
- * @param {Array} attributes 
+ * An attribute object.
+ * @typedef {Object} Attribute
+ * @property {Object} node - Indicates the value of the attribute returned from prettier/doc.
+ * @property {String[]} printed - Indicates the printed format of the attribute.
+ */
+
+/**
+ *
+ * @param {Array} attributes
  * @returns {Array} a copy of attributes that has been sorted
- * 
+ *
  * <p> This is complicated because we need to parse the xmlns out of the
  * attribute keys, prioritize xmlns attributes first, and then order
  * accordingly. This is because I would like to extend this in the future to
  * prioritize certain keys within certain namespaces.
  */
 function sortAttributes(attributes) {
-    attributes.sort(([key1], [key2]) => {
-      // Handle the highest priority attribute
-      if (isXmlns(key1)) { 
-        return -1; // param1 appears earlier when sorted
-      } else if (isXmlns(key2)) { 
-        return 1; // param1 appears later when sorted
-      }
-
-      if (containsNamespace(key1) && containsNamespace(key2)) {
-        return compareTwoNamespacedAttributeKeys(key1, key2);
-      }
-      // Handle the 1 but not both containing a namespace
-      if (containsNamespace(key1) && !containsNamespace(key2)) {
-        return -1; // key1 appears earlier when sorted
-      } else if (!containsNamespace(key1) && containsNamespace(key2)) {
-        return 1; // key1 appears later when sorted
-      }
-      return standardComparison(key1, key2);
-    })
-  }
-  
-  /**
-   * 
-   * @param {String} key1 
-   * @param {String} key2 
-   * @returns {Number} a comparison value
-   */
-  function compareTwoNamespacedAttributeKeys(key1, key2) {
-    const [ns1, k1] = key1.split(":");
-    const [ns2, k2] = key2.split(":");
-    // if namespaces are equal, simply compare keys
-    if (ns1 === ns2) {
-      return standardComparison(k1, k2);
+  attributes.sort((leftAttr, rightAttr) => {
+    const leftToken = leftAttr.node.children.Name[0].image;
+    const rightToken = rightAttr.node.children.Name[0].image;
+    // Handle the highest priority attribute
+    if (isXmlns(leftToken)) {
+      return -1; // param1 appears earlier when sorted
+    } else if (isXmlns(rightToken)) {
+      return 1; // param1 appears later when sorted
     }
-    // Handle the 1 but not both being an xmlns
-    if (isXmlns(ns1) && !isXmlns(ns2)) {
+
+    if (containsNamespace(leftToken) && containsNamespace(rightToken)) {
+      return compareTwoNamespacedAttributeKeys(leftToken, rightToken);
+    }
+    // Handle the 1 but not both containing a namespace
+    if (containsNamespace(leftToken) && !containsNamespace(rightToken)) {
       return -1; // key1 appears earlier when sorted
-    } else if (!isXmlns(ns1) && isXmlns(ns2)) {
+    } else if (!containsNamespace(leftToken) && containsNamespace(rightToken)) {
       return 1; // key1 appears later when sorted
     }
-    return standardComparison(ns1, ns2);
-  }
-  
-  /**
-   * 
-   * @param {String} key 
-   * @returns {Boolean} whether or not that key is namespace-d
-   */
-  function containsNamespace(key) {
-    return key.includes(":");
-  }
-  
-  /**
-   * 
-   * @param {String} value 
-   * @returns {Boolean} whether or not that value is xmlns
-   */
-  function isXmlns(value) {
-    return value === "xmlns";
-  }
-  
-  /**
-   * 
-   * @param {String} key1 
-   * @param {String} key2 
-   * @returns {Number} a comparison value
-   */
-  function standardComparison(key1, key2) {
-    if (key1 < key2) { 
-      return -1; // param1 appears earlier when sorted
-    } else if (key1 > key2) {
-      return 1; // param1 appears later when sorted
-    } else {
-      return 0;
-    }
-  }
+    return standardComparison(leftToken, rightToken);
+  });
+}
 
-  export default sortAttributes;
+/**
+ *
+ * @param {String} leftKey
+ * @param {String} rightKey
+ * @returns {Number} a comparison value
+ */
+function compareTwoNamespacedAttributeKeys(leftKey, rightKey) {
+  const [ns1, k1] = leftKey.split(":");
+  const [ns2, k2] = rightKey.split(":");
+  // if namespaces are equal, simply compare keys
+  if (ns1 === ns2) {
+    return standardComparison(k1, k2);
+  }
+  // Handle the 1 but not both being an xmlns
+  if (isXmlns(ns1) && !isXmlns(ns2)) {
+    return -1; // key1 appears earlier when sorted
+  } else if (!isXmlns(ns1) && isXmlns(ns2)) {
+    return 1; // key1 appears later when sorted
+  }
+  return standardComparison(ns1, ns2);
+}
+
+/**
+ *
+ * @param {String} key
+ * @returns {Boolean} whether or not that key is namespace-d
+ */
+function containsNamespace(key) {
+  return key.includes(":");
+}
+
+/**
+ *
+ * @param {String} value
+ * @returns {Boolean} whether or not that value is xmlns
+ */
+function isXmlns(value) {
+  return value === "xmlns";
+}
+
+/**
+ *
+ * @param {String} key1
+ * @param {String} key2
+ * @returns {Number} a comparison value
+ */
+function standardComparison(key1, key2) {
+  if (key1 < key2) {
+    return -1; // param1 appears earlier when sorted
+  } else if (key1 > key2) {
+    return 1; // param1 appears later when sorted
+  } else {
+    return 0;
+  }
+}
+
+export default sortAttributes;

--- a/src/util/sortAttributesByKey.js
+++ b/src/util/sortAttributesByKey.js
@@ -1,0 +1,89 @@
+/**
+ * 
+ * @param {Array} attributes 
+ * @returns {Array} a copy of attributes that has been sorted
+ * 
+ * <p> This is complicated because we need to parse the xmlns out of the
+ * attribute keys, prioritize xmlns attributes first, and then order
+ * accordingly. This is because I would like to extend this in the future to
+ * prioritize certain keys within certain namespaces.
+ */
+function sortAttributes(attributes) {
+    attributes.sort(([key1], [key2]) => {
+      // Handle the highest priority attribute
+      if (isXmlns(key1)) { 
+        return -1; // param1 appears earlier when sorted
+      } else if (isXmlns(key2)) { 
+        return 1; // param1 appears later when sorted
+      }
+
+      if (containsNamespace(key1) && containsNamespace(key2)) {
+        return compareTwoNamespacedAttributeKeys(key1, key2);
+      }
+      // Handle the 1 but not both containing a namespace
+      if (containsNamespace(key1) && !containsNamespace(key2)) {
+        return -1; // key1 appears earlier when sorted
+      } else if (!containsNamespace(key1) && containsNamespace(key2)) {
+        return 1; // key1 appears later when sorted
+      }
+      return standardComparison(key1, key2);
+    })
+  }
+  
+  /**
+   * 
+   * @param {String} key1 
+   * @param {String} key2 
+   * @returns {Number} a comparison value
+   */
+  function compareTwoNamespacedAttributeKeys(key1, key2) {
+    const [ns1, k1] = key1.split(":");
+    const [ns2, k2] = key2.split(":");
+    // if namespaces are equal, simply compare keys
+    if (ns1 === ns2) {
+      return standardComparison(k1, k2);
+    }
+    // Handle the 1 but not both being an xmlns
+    if (isXmlns(ns1) && !isXmlns(ns2)) {
+      return -1; // key1 appears earlier when sorted
+    } else if (!isXmlns(ns1) && isXmlns(ns2)) {
+      return 1; // key1 appears later when sorted
+    }
+    return standardComparison(ns1, ns2);
+  }
+  
+  /**
+   * 
+   * @param {String} key 
+   * @returns {Boolean} whether or not that key is namespace-d
+   */
+  function containsNamespace(key) {
+    return key.includes(":");
+  }
+  
+  /**
+   * 
+   * @param {String} value 
+   * @returns {Boolean} whether or not that value is xmlns
+   */
+  function isXmlns(value) {
+    return value === "xmlns";
+  }
+  
+  /**
+   * 
+   * @param {String} key1 
+   * @param {String} key2 
+   * @returns {Number} a comparison value
+   */
+  function standardComparison(key1, key2) {
+    if (key1 < key2) { 
+      return -1; // param1 appears earlier when sorted
+    } else if (key1 > key2) {
+      return 1; // param1 appears later when sorted
+    } else {
+      return 0;
+    }
+  }
+
+  export default sortAttributes;

--- a/test/__snapshots__/format.test.js.snap
+++ b/test/__snapshots__/format.test.js.snap
@@ -83,6 +83,34 @@ use {
   <div
     verylongattribute="verylongvalue"
     anotherverylongattribute="anotherverylongvalue" />
+
+  <div attr1='singleQuotes' att2="doubleQuotes" />
+
+  <!-- Basic sorting of xml attributes -->
+  <div z="third" y="second" x="first" />
+
+  <container xmlns:ios="iosURI" xmlns:android="androidURI">
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a">
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a" />
+    </foo>
+  </container>
 </svg>
 <!-- bar -->
 "
@@ -171,6 +199,34 @@ use {
   <div
     verylongattribute="verylongvalue"
     anotherverylongattribute="anotherverylongvalue"/>
+
+  <div attr1='singleQuotes' att2="doubleQuotes"/>
+
+  <!-- Basic sorting of xml attributes -->
+  <div z="third" y="second" x="first"/>
+
+  <container xmlns:ios="iosURI" xmlns:android="androidURI">
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a">
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a"/>
+    </foo>
+  </container>
 </svg>
 <!-- bar -->
 "
@@ -253,6 +309,36 @@ use {
     verylongattribute="verylongvalue"
     anotherverylongattribute="anotherverylongvalue"
   />
+
+  <div attr1='singleQuotes' att2="doubleQuotes" />
+
+   <!-- Basic sorting of xml attributes -->
+  <div z="third" y="second" x="first" />
+
+  <container xmlns:ios="iosURI" xmlns:android="androidURI">
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a"
+    > 
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a"
+      />
+    </foo>
+  </container>
 </svg>
 <!-- bar -->
 "
@@ -356,6 +442,158 @@ use {
     verylongattribute="verylongvalue"
     anotherverylongattribute="anotherverylongvalue"
   />
+
+  <div
+    attr1='singleQuotes'
+    att2="doubleQuotes"
+  />
+
+  <!-- Basic sorting of xml attributes -->
+  <div
+    z="third"
+    y="second"
+    x="first"
+  />
+
+  <container
+    xmlns:ios="iosURI"
+    xmlns:android="androidURI"
+  >
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a"
+    >
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a"
+      />
+    </foo>
+  </container>
+</svg>
+<!-- bar -->
+"
+`;
+
+exports[`sortAttributesByKey => true 1`] = `
+"<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<?xml-model href="project.rnc" type="application/relax-ng-compact-syntax"?>
+<!-- foo -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  height="100"
+  viewBox="0 0 200 100"
+  width="200"
+>
+  <title>Style inheritance and the use element</title>
+  <desc _attr="attr">
+    &anp; &#12345;
+    <![CDATA[
+      foo
+    ]]>
+    bar
+  </desc>
+  <?pagebreak?>
+
+  <style />
+  <style> </style>
+  <style type="text/css">
+circle {
+  stroke-opacity: 0.7;
+}
+.special circle {
+  stroke: green;
+}
+use {
+  stroke: purple;
+  fill: orange;
+}
+  </style>
+  <script value="lint" />
+
+  <yaml
+    myveryveryveryverylongattributename="myveryveryveryverylongattributevalue"
+  >
+- 1
+  - 2
+- 3
+  </yaml>
+
+  <!-- inner comment -->
+
+  <?pagebreak?>
+    <g class="special" style="fill: blue">
+        <circle cx="50" cy="50" id="c" r="40" stroke-width="20" />
+    </g>
+  <use xlink:href="#c" x="100" />
+  <ignored>
+    <!-- prettier-ignore-start -->
+      <   ignored   />
+    <!-- prettier-ignore-end -->
+  </ignored>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim. Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna. Curabitur molestie lorem et odio porta, et molestie libero laoreet. Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat. Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu, at condimentum neque elementum ut.
+  </p>
+  <span>
+    content
+  </span>
+
+  <div> text   with space<div><hr /></div>   </div>
+
+  <div>
+    even more
+    <content />
+  </div>
+
+  <div
+    anotherverylongattribute="anotherverylongvalue"
+    verylongattribute="verylongvalue"
+  />
+
+  <div att2="doubleQuotes" attr1='singleQuotes' />
+
+   <!-- Basic sorting of xml attributes -->
+  <div x="first" y="second" z="third" />
+
+  <container xmlns:android="androidURI" xmlns:ios="iosURI">
+    <foo
+      xmlns="highest priority"
+      xmlns:tools="toolsURI"
+      android:a="a"
+      android:b="b"
+      android:c="c"
+      android:d="d"
+      tools:other="thing"
+      here="!"
+      some="non-ns-ed-attributes"
+    > 
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        android:b="b"
+        ios:a="a"
+        ios:c="c"
+        ios:d="d"
+        otherTools:baz="bing"
+        tools:other="thing"
+        another="one"
+      />
+    </foo>
+  </container>
 </svg>
 <!-- bar -->
 "
@@ -447,6 +685,36 @@ use {
     verylongattribute="verylongvalue"
     anotherverylongattribute="anotherverylongvalue"
   />
+
+  <div attr1='singleQuotes' att2="doubleQuotes"/>
+
+  <!-- Basic sorting of xml attributes -->
+  <div z="third" y="second" x="first"/>
+
+  <container xmlns:ios="iosURI" xmlns:android="androidURI">
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a"
+    >
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a"
+      />
+    </foo>
+  </container>
 </svg>
 <!-- bar -->
 "
@@ -538,6 +806,36 @@ use {
     verylongattribute="verylongvalue"
     anotherverylongattribute="anotherverylongvalue"
   />
+
+  <div attr1='singleQuotes' att2="doubleQuotes" />
+
+  <!-- Basic sorting of xml attributes -->
+  <div z="third" y="second" x="first" />
+
+  <container xmlns:ios="iosURI" xmlns:android="androidURI">
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a"
+    >
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a"
+      />
+    </foo>
+  </container>
 </svg>
 <!-- bar -->
 "
@@ -622,6 +920,36 @@ use {
     verylongattribute="verylongvalue"
     anotherverylongattribute="anotherverylongvalue"
   />
+
+  <div attr1='singleQuotes' att2="doubleQuotes" />
+
+  <!-- Basic sorting of xml attributes -->
+  <div z="third" y="second" x="first" />
+
+  <container xmlns:ios="iosURI" xmlns:android="androidURI">
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a"
+    >
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a"
+      />
+    </foo>
+  </container>
 </svg>
 <!-- bar -->
 "

--- a/test/__snapshots__/format.test.js.snap
+++ b/test/__snapshots__/format.test.js.snap
@@ -595,6 +595,33 @@ use {
 
   <div attr1="singleQuotes" att2="doubleQuotes" />
 
+   <!-- Basic sorting of xml attributes -->
+  <div z="third" y="second" x="first" />
+
+  <container xmlns:ios="iosURI" xmlns:android="androidURI">
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a"
+    > 
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a"
+      />
+    </foo>
+  </container>
   <EscapeNeeded name="Pete &quot;Maverick&quot; Mitchell" />
 
   <NoEscapeNeeded>He said, "Don't quote me."</NoEscapeNeeded>
@@ -687,6 +714,33 @@ use {
 
   <div attr1='singleQuotes' att2="doubleQuotes" />
 
+   <!-- Basic sorting of xml attributes -->
+  <div z="third" y="second" x="first" />
+
+  <container xmlns:ios="iosURI" xmlns:android="androidURI">
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a"
+    > 
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a"
+      />
+    </foo>
+  </container>
   <EscapeNeeded name="Pete &quot;Maverick&quot; Mitchell" />
 
   <NoEscapeNeeded>He said, "Don't quote me."</NoEscapeNeeded>
@@ -779,6 +833,33 @@ use {
 
   <div attr1='singleQuotes' att2='doubleQuotes' />
 
+   <!-- Basic sorting of xml attributes -->
+  <div z='third' y='second' x='first' />
+
+  <container xmlns:ios='iosURI' xmlns:android='androidURI'>
+    <foo
+      xmlns:tools='toolsURI'
+      android:d='d'
+      android:c='c'
+      some='non-ns-ed-attributes'
+      here='!'
+      tools:other='thing'
+      android:b='b'
+      xmlns='highest priority'
+      android:a='a'
+    > 
+      <bar
+        xmlns:otherTools='otherToolsURI'
+        ios:d='d'
+        ios:c='c'
+        tools:other='thing'
+        another='one'
+        android:b='b'
+        otherTools:baz='bing'
+        ios:a='a'
+      />
+    </foo>
+  </container>
   <EscapeNeeded name='Pete &quot;Maverick&quot; Mitchell' />
 
   <NoEscapeNeeded>He said, "Don't quote me."</NoEscapeNeeded>
@@ -904,118 +985,6 @@ use {
         android:b="b"
         otherTools:baz="bing"
         ios:a="a"
-      />
-    </foo>
-  </container>
-</svg>
-<!-- bar -->
-"
-`;
-
-exports[`xmlSortAttributesByKey => true 1`] = `
-"<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-  "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
-<?xml-model href="project.rnc" type="application/relax-ng-compact-syntax"?>
-<!-- foo -->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
-  height="100"
-  viewBox="0 0 200 100"
-  width="200"
->
-  <title>Style inheritance and the use element</title>
-  <desc _attr="attr">
-    &anp; &#12345;
-    <![CDATA[
-      foo
-    ]]>
-    bar
-  </desc>
-  <?pagebreak?>
-
-  <style />
-  <style> </style>
-  <style type="text/css">
-circle {
-  stroke-opacity: 0.7;
-}
-.special circle {
-  stroke: green;
-}
-use {
-  stroke: purple;
-  fill: orange;
-}
-  </style>
-  <script value="lint" />
-
-  <yaml
-    myveryveryveryverylongattributename="myveryveryveryverylongattributevalue"
-  >
-- 1
-  - 2
-- 3
-  </yaml>
-
-  <!-- inner comment -->
-
-  <?pagebreak?>
-    <g class="special" style="fill: blue">
-        <circle cx="50" cy="50" id="c" r="40" stroke-width="20" />
-    </g>
-  <use xlink:href="#c" x="100" />
-  <ignored>
-    <!-- prettier-ignore-start -->
-      <   ignored   />
-    <!-- prettier-ignore-end -->
-  </ignored>
-  <p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim. Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna. Curabitur molestie lorem et odio porta, et molestie libero laoreet. Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat. Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu, at condimentum neque elementum ut.
-  </p>
-  <span>
-    content
-  </span>
-
-  <div> text   with space<div><hr /></div>   </div>
-
-  <div>
-    even more
-    <content />
-  </div>
-
-  <div
-    anotherverylongattribute="anotherverylongvalue"
-    verylongattribute="verylongvalue"
-  />
-
-  <div att2="doubleQuotes" attr1='singleQuotes' />
-
-   <!-- Basic sorting of xml attributes -->
-  <div x="first" y="second" z="third" />
-
-  <container xmlns:android="androidURI" xmlns:ios="iosURI">
-    <foo
-      xmlns="highest priority"
-      xmlns:tools="toolsURI"
-      android:a="a"
-      android:b="b"
-      android:c="c"
-      android:d="d"
-      tools:other="thing"
-      here="!"
-      some="non-ns-ed-attributes"
-    > 
-      <bar
-        xmlns:otherTools="otherToolsURI"
-        android:b="b"
-        ios:a="a"
-        ios:c="c"
-        ios:d="d"
-        otherTools:baz="bing"
-        tools:other="thing"
-        another="one"
       />
     </foo>
   </container>

--- a/test/__snapshots__/format.test.js.snap
+++ b/test/__snapshots__/format.test.js.snap
@@ -487,118 +487,6 @@ use {
 "
 `;
 
-exports[`sortAttributesByKey => true 1`] = `
-"<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-  "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
-<?xml-model href="project.rnc" type="application/relax-ng-compact-syntax"?>
-<!-- foo -->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
-  height="100"
-  viewBox="0 0 200 100"
-  width="200"
->
-  <title>Style inheritance and the use element</title>
-  <desc _attr="attr">
-    &anp; &#12345;
-    <![CDATA[
-      foo
-    ]]>
-    bar
-  </desc>
-  <?pagebreak?>
-
-  <style />
-  <style> </style>
-  <style type="text/css">
-circle {
-  stroke-opacity: 0.7;
-}
-.special circle {
-  stroke: green;
-}
-use {
-  stroke: purple;
-  fill: orange;
-}
-  </style>
-  <script value="lint" />
-
-  <yaml
-    myveryveryveryverylongattributename="myveryveryveryverylongattributevalue"
-  >
-- 1
-  - 2
-- 3
-  </yaml>
-
-  <!-- inner comment -->
-
-  <?pagebreak?>
-    <g class="special" style="fill: blue">
-        <circle cx="50" cy="50" id="c" r="40" stroke-width="20" />
-    </g>
-  <use xlink:href="#c" x="100" />
-  <ignored>
-    <!-- prettier-ignore-start -->
-      <   ignored   />
-    <!-- prettier-ignore-end -->
-  </ignored>
-  <p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim. Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna. Curabitur molestie lorem et odio porta, et molestie libero laoreet. Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat. Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu, at condimentum neque elementum ut.
-  </p>
-  <span>
-    content
-  </span>
-
-  <div> text   with space<div><hr /></div>   </div>
-
-  <div>
-    even more
-    <content />
-  </div>
-
-  <div
-    anotherverylongattribute="anotherverylongvalue"
-    verylongattribute="verylongvalue"
-  />
-
-  <div att2="doubleQuotes" attr1='singleQuotes' />
-
-   <!-- Basic sorting of xml attributes -->
-  <div x="first" y="second" z="third" />
-
-  <container xmlns:android="androidURI" xmlns:ios="iosURI">
-    <foo
-      xmlns="highest priority"
-      xmlns:tools="toolsURI"
-      android:a="a"
-      android:b="b"
-      android:c="c"
-      android:d="d"
-      tools:other="thing"
-      here="!"
-      some="non-ns-ed-attributes"
-    > 
-      <bar
-        xmlns:otherTools="otherToolsURI"
-        android:b="b"
-        ios:a="a"
-        ios:c="c"
-        ios:d="d"
-        otherTools:baz="bing"
-        tools:other="thing"
-        another="one"
-      />
-    </foo>
-  </container>
-</svg>
-<!-- bar -->
-"
-`;
-
 exports[`xmlSelfClosingSpace => false 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
@@ -712,6 +600,118 @@ use {
         android:b="b"
         otherTools:baz="bing"
         ios:a="a"
+      />
+    </foo>
+  </container>
+</svg>
+<!-- bar -->
+"
+`;
+
+exports[`xmlSortAttributesByKey => true 1`] = `
+"<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<?xml-model href="project.rnc" type="application/relax-ng-compact-syntax"?>
+<!-- foo -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  height="100"
+  viewBox="0 0 200 100"
+  width="200"
+>
+  <title>Style inheritance and the use element</title>
+  <desc _attr="attr">
+    &anp; &#12345;
+    <![CDATA[
+      foo
+    ]]>
+    bar
+  </desc>
+  <?pagebreak?>
+
+  <style />
+  <style> </style>
+  <style type="text/css">
+circle {
+  stroke-opacity: 0.7;
+}
+.special circle {
+  stroke: green;
+}
+use {
+  stroke: purple;
+  fill: orange;
+}
+  </style>
+  <script value="lint" />
+
+  <yaml
+    myveryveryveryverylongattributename="myveryveryveryverylongattributevalue"
+  >
+- 1
+  - 2
+- 3
+  </yaml>
+
+  <!-- inner comment -->
+
+  <?pagebreak?>
+    <g class="special" style="fill: blue">
+        <circle cx="50" cy="50" id="c" r="40" stroke-width="20" />
+    </g>
+  <use xlink:href="#c" x="100" />
+  <ignored>
+    <!-- prettier-ignore-start -->
+      <   ignored   />
+    <!-- prettier-ignore-end -->
+  </ignored>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed at est eget enim consectetur accumsan. Aliquam pretium sodales ipsum quis dignissim. Sed id sem vel diam luctus fringilla. Aliquam quis egestas magna. Curabitur molestie lorem et odio porta, et molestie libero laoreet. Morbi rhoncus sagittis cursus. Nullam vehicula pretium consequat. Praesent porta ante at posuere sollicitudin. Nullam commodo tempor arcu, at condimentum neque elementum ut.
+  </p>
+  <span>
+    content
+  </span>
+
+  <div> text   with space<div><hr /></div>   </div>
+
+  <div>
+    even more
+    <content />
+  </div>
+
+  <div
+    anotherverylongattribute="anotherverylongvalue"
+    verylongattribute="verylongvalue"
+  />
+
+  <div att2="doubleQuotes" attr1='singleQuotes' />
+
+   <!-- Basic sorting of xml attributes -->
+  <div x="first" y="second" z="third" />
+
+  <container xmlns:android="androidURI" xmlns:ios="iosURI">
+    <foo
+      xmlns="highest priority"
+      xmlns:tools="toolsURI"
+      android:a="a"
+      android:b="b"
+      android:c="c"
+      android:d="d"
+      tools:other="thing"
+      here="!"
+      some="non-ns-ed-attributes"
+    > 
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        android:b="b"
+        ios:a="a"
+        ios:c="c"
+        ios:d="d"
+        otherTools:baz="bing"
+        tools:other="thing"
+        another="one"
       />
     </foo>
   </container>

--- a/test/fixture.xml
+++ b/test/fixture.xml
@@ -63,5 +63,33 @@
   </div>
 
   <div verylongattribute="verylongvalue" anotherverylongattribute="anotherverylongvalue" />
+
+  <div attr1='singleQuotes' att2="doubleQuotes" />
+
+   <!-- Basic sorting of xml attributes -->
+  <div z="third" y="second" x="first" />
+
+  <container xmlns:ios="iosURI" xmlns:android="androidURI">
+    <foo
+      xmlns:tools="toolsURI"
+      android:d="d"
+      android:c="c"
+      some="non-ns-ed-attributes"
+      here="!"
+      tools:other="thing"
+      android:b="b"
+      xmlns="highest priority"
+      android:a="a"> 
+      <bar
+        xmlns:otherTools="otherToolsURI"
+        ios:d="d"
+        ios:c="c"
+        tools:other="thing"
+        another="one"
+        android:b="b"
+        otherTools:baz="bing"
+        ios:a="a" />
+    </foo>
+  </container>
 </svg>
 <!-- bar -->

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -76,6 +76,7 @@ test("xmlSortAttributesByKey => true", async () => {
   const formatted = await format(fixture, {
     xmlSortAttributesByKey: true
   });
+});
 
 test("xmlQuoteAttributes => preserve", async () => {
   const formatted = await format(fixture, {
@@ -97,5 +98,6 @@ test("xmlQuoteAttributes => double", async () => {
   const formatted = await format(fixture, {
     xmlQuoteAttributes: "double"
   });
+
   expect(formatted).toMatchSnapshot();
 });

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -71,3 +71,10 @@ test("xmlWhitespaceSensitivity => preserve", async () => {
 
   expect(formatted).toMatchSnapshot();
 });
+
+test("sortAttributesByKey => true", async () => {
+  const formatted = await format(fixture, {
+    sortAttributesByKey: true,
+  });
+  expect(formatted).toMatchSnapshot();
+});

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -72,9 +72,9 @@ test("xmlWhitespaceSensitivity => preserve", async () => {
   expect(formatted).toMatchSnapshot();
 });
 
-test("sortAttributesByKey => true", async () => {
+test("xmlSortAttributesByKey => true", async () => {
   const formatted = await format(fixture, {
-    sortAttributesByKey: true,
+    xmlSortAttributesByKey: true
   });
   expect(formatted).toMatchSnapshot();
 });


### PR DESCRIPTION
I would love to discuss this feature.  While technically this does agains the ethos of prettier, it is super common for xml files.  Especially android xml layout files.

Open to a discussion and totally okay with closing this out if you disagree with the validity of its use case.