### PR TITLE
Ensure the plugin doesn't use a different version of Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   },
   "homepage": "https://github.com/prettier/plugin-xml#readme",
   "dependencies": {
-    "@xml-tools/parser": "^1.0.11",
-    "prettier": ">=3.0.0"
+    "@xml-tools/parser": "^1.0.11"
+  },
+  "peerDependencies": {
+    "prettier": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^8.5.0",
@@ -30,7 +32,8 @@
     "husky": "^8.0.0",
     "jest": "^29.2.1",
     "linguist-languages": "^7.21.0",
-    "lint-staged": "^13.2.3"
+    "lint-staged": "^13.2.3",
+    "prettier": "^3.0.0"
   },
   "eslintConfig": {
     "extends": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2420,9 +2420,9 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@>=3.0.0:
+prettier@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
   integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-format@^29.6.1:


### PR DESCRIPTION
While waiting for the various Prettier plugins I use to update to v3, Dependabot created a PR for this one on its own (https://github.com/PREreview/prereview.org/pull/1083). It doesn't work, as two versions of Prettier are installed (v2 from my project and v3 as a dependency of this plugin).

This change makes Prettier a peer dependency to prevent multiple versions from being installed (matching the setup of other plugins). I've also restricted the version constraint to avoid advertising compatibility with Prettier 4+ (which might not be true).