### PR TITLE
Do not ignore whitespace in xsl:text nodes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,5 +6,6 @@
 /yarn.lock
 /LICENSE
 
+/.husky/
 /test/fixture.xml
 /test/__snapshots__/*

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Below are the options (from [`src/plugin.js`](src/plugin.js)) that `@prettier/pl
 
 | API Option                 | CLI Option                     |   Default    | Description                                                                                                              |
 | -------------------------- | ------------------------------ | :----------: | ------------------------------------------------------------------------------------------------------------------------ |
-| `bracketSameLine`          | `--bracket-same-line`          |    `true`    | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#bracket-line))                    |
+| `bracketSameLine`          | `--bracket-same-line`          |    `true`    | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#bracket-line))                         |
 | `printWidth`               | `--print-width`                |     `80`     | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#print-width)).                         |
 | `singleAttributePerLine`   | `--single-attribute-per-line`  |   `false`    | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#single-attribute-per-line))            |
 | `tabWidth`                 | `--tab-width`                  |     `2`      | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#tab-width)).                           |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint --cache .",
     "prepare": "node bin/languages.js && husky install",
-    "print": "prettier --plugin=.",
+    "print": "prettier --plugin=./src/plugin.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "repository": {
@@ -61,10 +61,12 @@
     "transform": {}
   },
   "prettier": {
+    "embeddedLanguageFormatting": "auto",
     "plugins": [
       "./src/plugin.js"
     ],
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "xmlWhitespaceSensitivity": "ignore"
   },
   "lint-staged": {
     "*.js": [

--- a/src/printer.js
+++ b/src/printer.js
@@ -26,10 +26,15 @@ function hasIgnoreRanges(comments) {
   return false;
 }
 
-function isWhitespaceIgnorable(opts, attributes, content) {
+function isWhitespaceIgnorable(opts, name, attributes, content) {
   // If the whitespace sensitivity setting is "strict", then we can't ignore the
   // whitespace.
   if (opts.xmlWhitespaceSensitivity === "strict") {
+    return false;
+  }
+
+  // If we have an xsl:text element, then we cannot ignore the whitespace.
+  if (name === "xsl:text") {
     return false;
   }
 
@@ -482,7 +487,7 @@ function printElement(path, opts, print) {
     END[0].image
   ]);
 
-  if (isWhitespaceIgnorable(opts, attribute, content[0])) {
+  if (isWhitespaceIgnorable(opts, Name[0].image, attribute, content[0])) {
     const fragments = path.call(
       (childrenPath) => printElementFragments(childrenPath, opts, print),
       "children",

--- a/test/__snapshots__/format.test.js.snap
+++ b/test/__snapshots__/format.test.js.snap
@@ -124,6 +124,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell' />
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell" />
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -253,6 +255,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell'/>
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell"/>
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -378,6 +382,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell' />
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell" />
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -540,6 +546,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell' />
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell" />
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -665,6 +673,8 @@ use {
   <NoEscapeNeeded name="Pete &quot;Maverick&quot; Mitchell" />
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell" />
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -790,6 +800,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell' />
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell" />
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -915,6 +927,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell' />
 
   <NoEscapeNeeded name='Pete &apos;Maverick&apos; Mitchell' />
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -1049,6 +1063,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell'/>
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell"/>
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -1174,6 +1190,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell' />
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell" />
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -1308,6 +1326,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell' />
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell" />
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "
@@ -1435,6 +1455,8 @@ use {
   <NoEscapeNeeded name='Pete "Maverick" Mitchell' />
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell" />
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->
 "

--- a/test/fixture.xml
+++ b/test/fixture.xml
@@ -104,5 +104,7 @@
   <NoEscapeNeeded name='Pete "Maverick" Mitchell'/>
 
   <NoEscapeNeeded name="Pete 'Maverick' Mitchell"/>
+
+  <xsl:text>slide </xsl:text>
 </svg>
 <!-- bar -->


### PR DESCRIPTION
Fixes https://github.com/prettier/plugin-xml/issues/748

@infotexture I'm going to go ahead and keep whitespace preserved entirely within xsl:text nodes. It just seems more correct.