### PR TITLE
prevent crash in locStart/locEnd when node location is undefined

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -204,9 +204,18 @@ const parser = {
   },
   astFormat: "xml",
   locStart(node) {
+    if (typeof node?.location?.startOffset !== "number") {
+      console.warn("locStart fallback triggered:", node);
+      return 0;
+    }
     return node.location.startOffset;
   },
+
   locEnd(node) {
+    if (typeof node?.location?.endOffset !== "number") {
+      console.warn("locEnd fallback triggered:", node);
+      return 0;
+    }
     return node.location.endOffset;
   }
 };


### PR DESCRIPTION
Prettier's formatWithCursor can crash if a node is missing a valid `location` object.

This patch adds null-safe checks and fallback handling in `locStart` and `locEnd` to avoid TypeErrors and ensure graceful degradation.