### PR TITLE
Stabilize XML declaration formatting on reformat

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -542,10 +542,16 @@ function printMisc(path, opts, print) {
 
 function printProlog(path, opts, print) {
   const { XMLDeclOpen, attribute, SPECIAL_CLOSE } = path.node;
-  const parts = [XMLDeclOpen];
+
+  // The XMLDeclOpen token includes the single whitespace character that follows
+  // "<?xml" (its pattern is /<\?xml[ \t\r\n]/). Printing that trailing
+  // whitespace verbatim is not stable: when the declaration breaks onto
+  // multiple lines a captured newline turns into an extra blank line on the
+  // next pass. Drop it and let the layout below supply the spacing.
+  const parts = ["<?xml"];
 
   if (attribute) {
-    parts.push(indent([softline, join(line, path.map(print, "attribute"))]));
+    parts.push(indent([line, join(line, path.map(print, "attribute"))]));
   }
 
   return group([

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -104,3 +104,13 @@ test("xmlQuoteAttributes => double", async () => {
 
   expect(formatted).toMatchSnapshot();
 });
+
+test("wrapped XML declaration is stable on reformat", async () => {
+  const input = '<?xml version="1.0" encoding="UTF-8"?>\n<root />\n';
+  const opts = { printWidth: 20 };
+
+  const once = await format(input, opts);
+  const twice = await format(once, opts);
+
+  expect(twice).toEqual(once);
+});


### PR DESCRIPTION
Running the plugin on its own output isn't stable when the XML declaration wraps. If a `<?xml … ?>` declaration is long enough (or `printWidth` small enough) to break onto multiple lines, the first pass produces

```
<?xml
  version="1.0"
  encoding="UTF-8"
?>
```

but a second pass inserts a blank line right after `<?xml`:

```
<?xml

  version="1.0"
  encoding="UTF-8"
?>
```

So formatted files don't pass `prettier --check`.

The cause is in `printProlog`: the `XMLDeclOpen` token's image isn't just `<?xml` — its lexer pattern is `/<\?xml[ \t\r\n]/`, so it also carries the one whitespace character that follows. We print that character verbatim. On a wrapped declaration that character is a newline, and printing it ahead of the line break that begins the attributes yields the extra blank line.

I print a normalized `<?xml` and let the existing layout supply the spacing (the leading `softline` becomes a `line` so the single-line case keeps its space). The common single-line output is unchanged, and a wrapped declaration now round-trips. Added a test that formats a wrapped declaration twice and asserts the second pass is a no-op.
