### PR TITLE
Fix indentation of nested elements in preserved mixed content

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -464,7 +464,7 @@ function printElement(path, opts, print) {
     ) {
       return group([
         openTag,
-        fragments.map(({ printed }) => printed),
+        indent(fragments.map(({ printed }) => printed)),
         closeTag
       ]);
     }

--- a/test/__snapshots__/format.test.js.snap
+++ b/test/__snapshots__/format.test.js.snap
@@ -1400,8 +1400,8 @@ use {
   </span>
 
   <div> text   with space<div>
-    <hr />
-  </div>   </div>
+      <hr />
+    </div>   </div>
 
   <div>
     even more

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -73,6 +73,52 @@ test("xmlWhitespaceSensitivity => preserve", async () => {
   expect(formatted).toMatchSnapshot();
 });
 
+test.each([2, 4])(
+  "preserve indents nested elements after text with tabWidth %i",
+  async (tabWidth) => {
+    const space = " ".repeat(tabWidth);
+    const input = [
+      "<root>",
+      `${space}<a>`,
+      `${space.repeat(2)}Text`,
+      `${space.repeat(2)}<b>`,
+      `${space.repeat(3)}<c />`,
+      `${space.repeat(2)}</b>`,
+      `${space}</a>`,
+      "</root>",
+      ""
+    ].join("\n");
+    const options = { xmlWhitespaceSensitivity: "preserve", tabWidth };
+
+    const formatted = await format(input, options);
+    expect(formatted).toBe(input);
+    expect(await format(formatted, options)).toBe(formatted);
+  }
+);
+
+test("preserve indents nested elements after text with tabs", async () => {
+  const input = "<a>\n\tText\n\t<b>\n\t\t<c />\n\t</b>\n</a>\n";
+  expect(
+    await format(input, { xmlWhitespaceSensitivity: "preserve", useTabs: true })
+  ).toBe(input);
+});
+
+test("preserve keeps inline mixed text whitespace", async () => {
+  const input = "<a> before  <b> middle  </b> after </a>\n";
+  expect(await format(input, { xmlWhitespaceSensitivity: "preserve" })).toBe(
+    input
+  );
+});
+
+test.each(["strict", "preserve", "ignore"])(
+  "xml:space preserves mixed content in %s mode",
+  async (xmlWhitespaceSensitivity) => {
+    const input =
+      '<a xml:space="preserve">\n  Text\n  <b>\n    <c />\n  </b>\n</a>\n';
+    expect(await format(input, { xmlWhitespaceSensitivity })).toBe(input);
+  }
+);
+
 test("xmlSortAttributesByKey => true", async () => {
   const formatted = await format(fixture, {
     xmlSortAttributesByKey: true


### PR DESCRIPTION
Fixes #995.

With `xmlWhitespaceSensitivity: "preserve"`, an element following a text sibling loses one indentation level inside its body. Wrap the preserved fragments in the existing `indent` document builder, so child documents retain their parent indentation. Literal text whitespace continues to use `literalline` and remains unchanged.

Add regression coverage for nested mixed content with 2- and 4-space indentation, tabs, formatting stability, inline text whitespace, and `xml:space="preserve"` across all whitespace modes. Update only the two affected indentation lines in the existing preserve snapshot.

Validation on Windows, Node 25.8.1, Prettier 3.9.6:

- Three regression tests fail before the fix; all 24 tests and 11 snapshots pass afterward (`npm test -- --runInBand`).
- The original public `prettier.format` reproduction passes with unchanged assertions, including strict and element-only controls.
- `npm run lint`, formatting checks for the changed files, and `git diff --check` pass.
- Full formatting passes with `--end-of-line auto`. The default full check flags pre-existing Windows CRLF checkout files; their HEAD blobs and LF-normalized contents pass the formatter. Unrelated files were not rewritten.

Linux/CI Node 20 was not run locally. This patch and its tests were prepared with AI assistance.
